### PR TITLE
Deploy 15-01-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [1.2.9](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.2.8...v1.2.9) (2025-01-14)
+
+### Chores
+
+* Bump version of mariadb for local development ([afb5ac](https://github.com/UN-OCHA/ai-summarize-site/commit/afb5ac7118988e510e0e00a5108d7fa5b590c822))
+* Update all outdated drupal/* unocha/* drush/* packages. ([a069f7](https://github.com/UN-OCHA/ai-summarize-site/commit/a069f78b15fe8a7288f0340d09194e07eac36c4f), [a66ab5](https://github.com/UN-OCHA/ai-summarize-site/commit/a66ab5aaa245fc4b6c0063017cbcc398e54a83e3), [b1cf2c](https://github.com/UN-OCHA/ai-summarize-site/commit/b1cf2c975dfbbaea3be09556d2a028a302fa61b6), [534a44](https://github.com/UN-OCHA/ai-summarize-site/commit/534a447651176584d4c015ba6f490a7a53072e9f))
+
+##### Tests
+
+* Bump the test MariaDB to match what the dev sites will use soon. (#178) ([40f1e3](https://github.com/UN-OCHA/ai-summarize-site/commit/40f1e3fd01e6145a7f3420785a6dbeee2916c0cb))
+
 ## [1.2.8](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.2.7...v1.2.8) (2024-12-16)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -249,5 +249,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "1.2.8"
+    "version": "1.2.9"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3aaa2f5db43269c341b47dec9f3d5d4",
+    "content-hash": "417f3f87d3f0bb0eb8c15cc84f0f7c76",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - default
 
   mysql:
-    image: public.ecr.aws/unocha/mysql:10.6
+    image: public.ecr.aws/unocha/mysql:11.4
     hostname: ai-summarize-test-mysql
     container_name: ai-summarize-test-mysql
     environment:


### PR DESCRIPTION
## [1.2.9](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.2.8...v1.2.9) (2025-01-14)

### Chores

* Bump version of mariadb for local development ([afb5ac](https://github.com/UN-OCHA/ai-summarize-site/commit/afb5ac7118988e510e0e00a5108d7fa5b590c822))
* Update all outdated drupal/* unocha/* drush/* packages. ([a069f7](https://github.com/UN-OCHA/ai-summarize-site/commit/a069f78b15fe8a7288f0340d09194e07eac36c4f), [a66ab5](https://github.com/UN-OCHA/ai-summarize-site/commit/a66ab5aaa245fc4b6c0063017cbcc398e54a83e3), [b1cf2c](https://github.com/UN-OCHA/ai-summarize-site/commit/b1cf2c975dfbbaea3be09556d2a028a302fa61b6), [534a44](https://github.com/UN-OCHA/ai-summarize-site/commit/534a447651176584d4c015ba6f490a7a53072e9f))

##### Tests

* Bump the test MariaDB to match what the dev sites will use soon. (#178) ([40f1e3](https://github.com/UN-OCHA/ai-summarize-site/commit/40f1e3fd01e6145a7f3420785a6dbeee2916c0cb))

## Composer changes

| Production Changes                 | From     | To       | Compare                                                                                  |
|------------------------------------|----------|----------|------------------------------------------------------------------------------------------|
| aws/aws-sdk-php                    | 3.334.4  | 3.336.11 | [...](https://github.com/aws/aws-sdk-php/compare/3.334.4...3.336.11)                     |
| composer/ca-bundle                 | 1.5.4    | 1.5.5    | [...](https://github.com/composer/ca-bundle/compare/1.5.4...1.5.5)                       |
| consolidation/annotated-command    | 4.10.0   | 4.10.1   | [...](https://github.com/consolidation/annotated-command/compare/4.10.0...4.10.1)        |
| consolidation/site-alias           | 4.1.0    | 4.1.1    | [...](https://github.com/consolidation/site-alias/compare/4.1.0...4.1.1)                 |
| consolidation/site-process         | 5.4.0    | 5.4.2    | [...](https://github.com/consolidation/site-process/compare/5.4.0...5.4.2)               |
| doctrine/common                    | 3.4.5    | 3.5.0    | [...](https://github.com/doctrine/common/compare/3.4.5...3.5.0)                          |
| doctrine/persistence               | 3.4.0    | 4.0.0    | [...](https://github.com/doctrine/persistence/compare/3.4.0...4.0.0)                     |
| drupal/coder                       | 8.3.26   | 8.3.27   | [...](https://github.com/pfrenssen/coder/compare/8.3.26...8.3.27)                        |
| drupal/core                        | 10.3.10  | 10.4.1   | [...](https://github.com/drupal/core/compare/10.3.10...10.4.1)                           |
| drupal/core-composer-scaffold      | 10.3.10  | 10.4.1   | [...](https://github.com/drupal/core-composer-scaffold/compare/10.3.10...10.4.1)         |
| drupal/core-dev                    | 10.3.10  | 10.4.1   | [...](https://github.com/drupal/core-dev/compare/10.3.10...10.4.1)                       |
| drupal/core-recommended            | 10.3.10  | 10.4.1   | [...](https://github.com/drupal/core-recommended/compare/10.3.10...10.4.1)               |
| drupal/environment_indicator       | 4.0.19   | 4.0.21   | [...](https://git.drupalcode.org/project/environment_indicator/compare/4.0.19...4.0.21)  |
| drupal/monitoring                  | 1.14.0   | 1.15.0   | [...](https://git.drupalcode.org/project/monitoring/compare/1.14.0...1.15.0)             |
| drupal/sophron                     | 2.1.0    | 2.2.0    | [...](https://git.drupalcode.org/project/sophron/compare/2.1.0...2.2.0)                  |
| egulias/email-validator            | 4.0.2    | 4.0.3    | [...](https://github.com/egulias/EmailValidator/compare/4.0.2...4.0.3)                   |
| fileeye/mimemap                    | 2.2.0    | 2.2.1    | [...](https://github.com/FileEye/MimeMap/compare/2.2.0...2.2.1)                          |
| google/protobuf                    | v4.29.1  | v4.29.3  | [...](https://github.com/protocolbuffers/protobuf-php/compare/v4.29.1...v4.29.3)         |
| guzzlehttp/guzzle                  | 7.8.2    | 7.9.2    | [...](https://github.com/guzzle/guzzle/compare/7.8.2...7.9.2)                            |
| guzzlehttp/psr7                    | 2.6.3    | 2.7.0    | [...](https://github.com/guzzle/psr7/compare/2.6.3...2.7.0)                              |
| nikic/php-parser                   | v5.3.1   | v5.4.0   | [...](https://github.com/nikic/PHP-Parser/compare/v5.3.1...v5.4.0)                       |
| open-telemetry/api                 | 1.1.1    | 1.2.0    | [...](https://github.com/opentelemetry-php/api/compare/1.1.1...1.2.0)                    |
| open-telemetry/exporter-otlp       | 1.1.0    | 1.2.0    | [...](https://github.com/opentelemetry-php/exporter-otlp/compare/1.1.0...1.2.0)          |
| open-telemetry/sdk                 | 1.1.2    | 1.2.0    | [...](https://github.com/opentelemetry-php/sdk/compare/1.1.2...1.2.0)                    |
| phpstan/phpstan                    | 1.12.12  | 1.12.15  | [...](https://github.com/phpstan/phpstan/compare/1.12.12...1.12.15)                      |
| phpstan/phpstan-phpunit            | 1.4.1    | 1.4.2    | [...](https://github.com/phpstan/phpstan-phpunit/compare/1.4.1...1.4.2)                  |
| sirbrillig/phpcs-variable-analysis | v2.11.21 | v2.11.22 | [...](https://github.com/sirbrillig/phpcs-variable-analysis/compare/v2.11.21...v2.11.22) |
| symfony/console                    | v6.4.15  | v6.4.17  | [...](https://github.com/symfony/console/compare/v6.4.15...v6.4.17)                      |
| symfony/error-handler              | v6.4.14  | v6.4.17  | [...](https://github.com/symfony/error-handler/compare/v6.4.14...v6.4.17)                |
| symfony/finder                     | v6.4.13  | v6.4.17  | [...](https://github.com/symfony/finder/compare/v6.4.13...v6.4.17)                       |
| symfony/http-kernel                | v6.4.16  | v6.4.17  | [...](https://github.com/symfony/http-kernel/compare/v6.4.16...v6.4.17)                  |
| symfony/mime                       | v6.4.13  | v6.4.17  | [...](https://github.com/symfony/mime/compare/v6.4.13...v6.4.17)                         |
| symfony/polyfill-ctype             | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-ctype/compare/v1.29.0...v1.31.0)               |
| symfony/polyfill-iconv             | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-iconv/compare/v1.29.0...v1.31.0)               |
| symfony/polyfill-intl-grapheme     | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-intl-grapheme/compare/v1.29.0...v1.31.0)       |
| symfony/polyfill-intl-idn          | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-intl-idn/compare/v1.29.0...v1.31.0)            |
| symfony/polyfill-intl-normalizer   | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-intl-normalizer/compare/v1.29.0...v1.31.0)     |
| symfony/polyfill-mbstring          | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-mbstring/compare/v1.29.0...v1.31.0)            |
| symfony/polyfill-php72             | v1.31.0  | REMOVED  |                                                                                          |
| symfony/polyfill-php83             | v1.29.0  | v1.31.0  | [...](https://github.com/symfony/polyfill-php83/compare/v1.29.0...v1.31.0)               |
| symfony/validator                  | v6.4.16  | v6.4.17  | [...](https://github.com/symfony/validator/compare/v6.4.16...v6.4.17)                    |
| twig/twig                          | v3.14.2  | v3.16.0  | [...](https://github.com/twigphp/Twig/compare/v3.14.2...v3.16.0)                         |

