### PR TITLE
Deploy 21-02-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [1.4.0](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.3.0...v1.4.0) (2025-02-20)
+
+### Features
+
+* Use admin theme to manage people ([5ca6bc](https://github.com/UN-OCHA/ai-summarize-site/commit/5ca6bc7c408a1f287ac92e952c0489f6a1f096f1))
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([92c580](https://github.com/UN-OCHA/ai-summarize-site/commit/92c58030fe6ed3dab9b55fc9e99d1206c63390cc))
+
 ## [1.3.0](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.2.9...v1.3.0) (2025-02-18)
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -248,5 +248,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "1.3.0"
+    "version": "1.4.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "586fd402b2e43b6c8e3af4f5602da5c1",
+    "content-hash": "25ddcb1011d3411a9aa92dcc0ea6010d",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [1.4.0](https://github.com/UN-OCHA/ai-summarize-site/compare/v1.3.0...v1.4.0) (2025-02-20)

### Features

* Use admin theme to manage people ([5ca6bc](https://github.com/UN-OCHA/ai-summarize-site/commit/5ca6bc7c408a1f287ac92e952c0489f6a1f096f1))

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([92c580](https://github.com/UN-OCHA/ai-summarize-site/commit/92c58030fe6ed3dab9b55fc9e99d1206c63390cc))

## Composer changes

| Production Changes            | From     | To       | Compare                                                                         |
|-------------------------------|----------|----------|---------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.339.12 | 3.339.17 | [...](https://github.com/aws/aws-sdk-php/compare/3.339.12...3.339.17)           |
| drupal/core                   | 10.4.2   | 10.4.3   | [...](https://github.com/drupal/core/compare/10.4.2...10.4.3)                   |
| drupal/core-composer-scaffold | 10.4.2   | 10.4.3   | [...](https://github.com/drupal/core-composer-scaffold/compare/10.4.2...10.4.3) |
| drupal/core-dev               | 10.4.2   | 10.4.3   | [...](https://github.com/drupal/core-dev/compare/10.4.2...10.4.3)               |
| drupal/core-recommended       | 10.4.2   | 10.4.3   | [...](https://github.com/drupal/core-recommended/compare/10.4.2...10.4.3)       |
| drupal/monitoring             | 1.15.0   | 1.16.0   | [...](https://git.drupalcode.org/project/monitoring/compare/1.15.0...1.16.0)    |
| phpstan/phpstan               | 1.12.17  | 1.12.19  | [...](https://github.com/phpstan/phpstan/compare/1.12.17...1.12.19)             |

