### PR TITLE
updates: allow scripts in update workflow

### DIFF
--- a/.github/workflows/composer-update-scripts.yml
+++ b/.github/workflows/composer-update-scripts.yml
@@ -1,18 +1,21 @@
-name: Run Composer Update with Config
+name: Run Composer Update with Scripts
 
 on:
+  schedule:
+    - cron: '30 6 * * 4'
   workflow_dispatch:
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - name: Update The Thing with config
-      id: update-action-with-config
-      uses: UN-OCHA/actions/composer-update@OPS-10254-config-too
+    - name: Update The Thing with scripts
+      id: update-action-with-scripts
+      uses: UN-OCHA/actions/composer-update@OPS-11381-scripts-flag
       with:
         aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+        composer_scripts: "true"
         github_access_token: ${{ secrets.PAT }}
         patch_branch: ${{ github.head_ref || github.ref_name }}
         patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}

--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -1,8 +1,6 @@
 name: Run Composer Update
 
 on:
-  schedule:
-    - cron: '30 6 * * 4'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Refs: OPS-11375

This is to allow drupal-lenient scripts to run so the update doesn't fail because of the maintenance200 module.
